### PR TITLE
Remove dependency on jQuery browser global.

### DIFF
--- a/lib/jquery.tinyscrollbar.js
+++ b/lib/jquery.tinyscrollbar.js
@@ -2,11 +2,11 @@
 {
     if (typeof define === 'function' && define.amd)
     {
-        define(jQuery || ['jquery'], factory);
+        define(['jquery'], factory);
     }
     else if (typeof exports === 'object')
     {
-        factory(jQuery || require('jquery'));
+        factory(require('jquery'));
     }
     else
     {


### PR DESCRIPTION
jQuery ought to be loaded as a dependency in an AMD environment; the jQuery browser global detection should be removed from the factory function.

https://github.com/umdjs/umd/blob/master/jqueryPluginCommonjs.js
