### PR TITLE
Fix two resize() handler glitches when disabled

### DIFF
--- a/lib/tinyscrollbar.js
+++ b/lib/tinyscrollbar.js
@@ -185,7 +185,7 @@
             this.trackRatio = (this.contentSize - this.viewportSize) / (this.trackSize - this.thumbSize);
             this.hasContentToSroll = this.contentRatio < 1;
 
-            $scrollbar.className = this.hasContentToSroll ? scrcls.replace(/disable/g, "") : scrcls + " disable";
+            $scrollbar.className = this.hasContentToSroll ? scrcls.replace(/disable/g, "") : scrcls.replace(/ disable/g, "") + " disable";
 
             switch (scrollTo) {
                 case "bottom":
@@ -193,7 +193,7 @@
                     break;
 
                 case "relative":
-                    this.contentPosition = Math.min(this.contentSize - this.viewportSize, Math.max(0, this.contentPosition));
+                    this.contentPosition = Math.min(Math.max(this.contentSize - this.viewportSize, 0), Math.max(0, this.contentPosition));
                     break;
 
                 default:


### PR DESCRIPTION
The ```resize``` event handler calls update with a 'relative' scroll. Two things happen in this case:

1. The 'disabled' class is added MANY times - once for every pixel of resize (see below about debouncing)
1. If the content size is less than the viewport size, a negative offset is added as part of the relative scroll. This causes the content to 'jump' down by the difference.

Note that it would probably also be a very good idea to 'debounce' this event handler... I wasn't sure what your preferred mechanism for that might be so I didn't include it here.