### PR TITLE
Stop wheel event propagation to support nested scrollbars

### DIFF
--- a/lib/jquery.tinyscrollbar.js
+++ b/lib/jquery.tinyscrollbar.js
@@ -317,6 +317,7 @@
                     evntObj.preventDefault();
                 }
             }
+            event.stopPropagation();
         }
 
         /**

--- a/lib/tinyscrollbar.js
+++ b/lib/tinyscrollbar.js
@@ -324,6 +324,7 @@
                     evntObj.preventDefault();
                 }
             }
+            event.stopPropagation();
         }
 
         /**


### PR DESCRIPTION
Nested scrollbars are currently broken in regard to the wheel event. When you try scrolling the inner scrollbar the outer scrollbar is also scrolled.

Stopping the wheel event makes this work as expected. I'm not sure if / what drawbacks could this introduce, for my testcase this seems to work just fine.